### PR TITLE
imgui: add a back button to the menubar

### DIFF
--- a/repentogon/ImGuiFeatures/ImGui.cpp
+++ b/repentogon/ImGuiFeatures/ImGui.cpp
@@ -498,6 +498,7 @@ HOOK_GLOBAL(OpenGL::wglSwapBuffers, (HDC hdc)->bool, __stdcall)
 
 	if (menuShown) {
 		if (ImGui::BeginMainMenuBar()) {
+			ImGui::MenuItem(ICON_FA_CHEVRON_LEFT"",NULL,&menuShown);
 			if (ImGui::BeginMenu(ICON_FA_SCREWDRIVER_WRENCH " Tools")) {
 				ImGui::MenuItem(ICON_FA_TERMINAL" Debug Console", NULL, &console.enabled);
 				ImGui::MenuItem(ICON_FA_NEWSPAPER" Log Viewer", NULL, &logViewer.enabled);


### PR DESCRIPTION
Baby's first cpp commit ;p

This PR adds a "Back" button to the ImGui's menu bar, allowing users to hide the overlay without the usage of a keyboard:
![image](https://github.com/TeamREPENTOGON/REPENTOGON/assets/18075164/a5dc57b7-a695-465f-b4ea-a005ed36b5e3)
