### PR TITLE
TrySpawnSpecialQuestDoor( boolean IgnoreStageType )

### DIFF
--- a/docs/docs/Room.md
+++ b/docs/docs/Room.md
@@ -9,8 +9,13 @@ tags:
 ### SpawnGridEntity () {: aria-label='Modified Functions' }
 #### boolean SpawnGridEntity ( int GridIndex, [GridEntityType](https://wofsauge.github.io/IsaacDocs/rep/enums/GridEntityType.html) Type, int Variant = 0, int Seed = nil, int VarData = 0 ) {: .copyable aria-label='Modified Functions' }
 #### boolean SpawnGridEntity ( int GridIndex, [GridEntityDesc](https://wofsauge.github.io/IsaacDocs/rep/GridEntityDesc.html) Descriptor) {: .copyable aria-label='Modified Functions' }
-
 No longer crashes if an invalid `GridIndex` is used. All arguments beyond `Type` are optional. An overload has been added to allow spawning a new grid entity using an existing `GridEntityDesc`.
+
+___
+### TrySpawnSpecialQuestDoor () {: aria-label='Modified Functions' }
+#### boolean TrySpawnSpecialQuestDoor ( boolean IgnoreStageType = false ) {: .copyable aria-label='Modified Functions' }
+An `IgnoreStageType` parameter has been added to allow spawning the Mirror & Mineshaft door outside of `STAGETYPE_REPENTANCE` and `STAGETYPE_REPENTANCE_B` stages. Note that the `KNIFE_PUZZLE` [dimension](Level.md?#dimension-getdimension) must be set up properly for these doors not to crash on entry!
+
 ___
 
 ## Functions

--- a/libzhl/functions/Room.zhl
+++ b/libzhl/functions/Room.zhl
@@ -67,6 +67,9 @@ __thiscall int Room::TryGetShopDiscount(int shopItemIdx, int price);
 "558bec8b45??83f82a":
 bool Room::IsPersistentRoomEntity(int type, int variant, int subtype);
 
+"558bec83ec0ca1????????53894d":
+__thiscall bool Room::TrySpawnSpecialQuestDoor();
+
 struct Room depends (EntityList, RoomDescriptor, TemporaryEffects, RailManager) {
 {{
 	inline Camera* GetCamera() { return *(Camera**)((char*)this + 0x11F8); }

--- a/repentogon/LuaInterfaces/Room/LuaRoom.cpp
+++ b/repentogon/LuaInterfaces/Room/LuaRoom.cpp
@@ -1,6 +1,7 @@
 #include "IsaacRepentance.h"
 #include "LuaCore.h"
 #include "HookSystem.h"
+#include "Room.h"
 
 LUA_FUNCTION(Lua_SpawnGridEntity) {
 	Room* room = lua::GetUserdata<Room*>(L, 1, lua::Metatables::ROOM, lua::metatables::RoomMT);
@@ -289,6 +290,13 @@ LUA_FUNCTION(Lua_RoomIsPersistentRoomEntity) {
 	return 1;
 }
 
+LUA_FUNCTION(Lua_RoomTrySpawnSpecialQuestDoor) {
+	Room* room = lua::GetUserdata<Room*>(L, 1, lua::Metatables::ROOM, lua::metatables::RoomMT);
+	roomASM.ForceSpecialQuestDoor = lua::luaL_checkboolean(L, 2);
+	lua_pushboolean(L, room->TrySpawnSpecialQuestDoor());
+	return 1;
+}
+
 HOOK_METHOD(LuaEngine, RegisterClasses, () -> void) {
 	super();
 
@@ -324,6 +332,7 @@ HOOK_METHOD(LuaEngine, RegisterClasses, () -> void) {
 		{ "GetGreedWaveTimer", Lua_RoomGetGreedWaveTimer},
 		{ "SetGreedWaveTimer", Lua_RoomSetGreedWaveTimer},
 		{ "IsPersistentRoomEntity", Lua_RoomIsPersistentRoomEntity},
+		{ "TrySpawnSpecialQuestDoor", Lua_RoomTrySpawnSpecialQuestDoor},
 		{ NULL, NULL }
 	};
 	lua::RegisterFunctions(_state, lua::Metatables::ROOM, functions);

--- a/repentogon/LuaInterfaces/Room/LuaRoom.cpp
+++ b/repentogon/LuaInterfaces/Room/LuaRoom.cpp
@@ -3,6 +3,8 @@
 #include "HookSystem.h"
 #include "Room.h"
 
+RoomASM roomASM;
+
 LUA_FUNCTION(Lua_SpawnGridEntity) {
 	Room* room = lua::GetUserdata<Room*>(L, 1, lua::Metatables::ROOM, lua::metatables::RoomMT);
 	bool ret = false;
@@ -292,7 +294,7 @@ LUA_FUNCTION(Lua_RoomIsPersistentRoomEntity) {
 
 LUA_FUNCTION(Lua_RoomTrySpawnSpecialQuestDoor) {
 	Room* room = lua::GetUserdata<Room*>(L, 1, lua::Metatables::ROOM, lua::metatables::RoomMT);
-	roomASM.ForceSpecialQuestDoor = lua::luaL_checkboolean(L, 2);
+	roomASM.ForceSpecialQuestDoor = lua::luaL_optboolean(L, 2, false);
 	lua_pushboolean(L, room->TrySpawnSpecialQuestDoor());
 	return 1;
 }

--- a/repentogon/LuaInterfaces/Room/Room.h
+++ b/repentogon/LuaInterfaces/Room/Room.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct RoomASM {
+	bool ForceSpecialQuestDoor;
+};
+
+extern RoomASM roomASM;

--- a/repentogon/LuaInterfaces/Room/Room.h
+++ b/repentogon/LuaInterfaces/Room/Room.h
@@ -1,7 +1,7 @@
 #pragma once
 
 struct RoomASM {
-	bool ForceSpecialQuestDoor;
+	bool ForceSpecialQuestDoor = false;
 };
 
 extern RoomASM roomASM;


### PR DESCRIPTION
This pull request adds an `IgnoreStageType` parameter to the vanilla function `TrySpawnSpecialQuestDoor`. This is in service of mods currently attempting to mimic alt-path floors without actually being on the alt-path StageTypes.