### PR TITLE
Beam & Point optimizations

### DIFF
--- a/docs/docs/renderer/Beam.md
+++ b/docs/docs/renderer/Beam.md
@@ -12,24 +12,27 @@ Note that this is a low-level class that strictly handles rendering. We hope to 
 
 ## Constructors
 ### Beam () {: aria-label='Constructors' }
-#### [Beam](Beam.md) Beam ( [Sprite](../Sprite.md) Sprite, int Layer, boolean UseOverlay, boolean UnkBool, int PointsPreallocateSize = 8) {: .copyable aria-label='Constructors' }
-#### [Beam](Beam.md) Beam ( [Sprite](../Sprite.md) Sprite, string LayerName, boolean UseOverlay, boolean UnkBool int PointsPreallocateSize = 8) {: .copyable aria-label='Constructors' }
+#### [Beam](Beam.md) Beam ( [Sprite](../Sprite.md) Sprite, int Layer, boolean UseOverlay, boolean UnkBool ) {: .copyable aria-label='Constructors' }
+#### [Beam](Beam.md) Beam ( [Sprite](../Sprite.md) Sprite, string LayerName, boolean UseOverlay, boolean UnkBool ) {: .copyable aria-label='Constructors' }
 
-???- note "Notes"
-	`PointsPreallocateSize` is the amount of space that `Beam` will reserve to hold points. This is not a hard limit, but going past this amount will incur a performance cost as more memory must be allocated to hold new ones.
+???+ warning "Warning"
+	The `Sprite` used in the Beam must be in the same "scope" as the Beam. For example, a global `Sprite` and `local Beam` works, but `local Sprite` and global `Beam` won't. They can also both be global/local or in the same table.
 
 ???- example "Example Code"
 	Here is an example of how you would use this class:
 
     ```lua
+	local spritesheetHeight = 64
+	
 	local sprite = Sprite()
 	sprite:Load("gfx/1000.193_anima chain.anm2", true)
+	sprite:Play("Idle", false)
+	
+	local layer = sprite:GetLayer("chain")
+	layer:SetWrapSMode(1)
+	layer:SetWrapTMode(0)
+	
 	local chain = Beam(sprite, "chain", false, false)
-	chain:GetSprite():Play("Idle", false)
-	local layer = chain:GetSprite():GetLayer("chain")
-	layer:SetWrapSMode(1) -- these are critical, otherwise
-	layer:SetWrapTMode(0) -- the beam sprite won't wrap!
-	local spritesheetHeight = 64
 
 	mod:AddCallback(ModCallbacks.MC_PRE_PLAYER_RENDER, function(_, player)
 		local origin = Isaac.WorldToScreen(Game():GetRoom():GetCenterPos())
@@ -65,7 +68,7 @@ Returns a table of the [Points](Point.md) currently stored.
 ___
 
 ### GetSprite () {: aria-label='Functions' }
-#### [Sprite](../Sprite.md) GetSprite ( ) {: .copyable aria-label='Functions' }   
+#### [Sprite](../Sprite.md) GetSprite ( ) {: .copyable aria-label='Functions' }
 
 ___
 ### GetUnkBool () {: aria-label='Functions' }
@@ -91,7 +94,9 @@ Sets the [Points](Point.md) used by this.
 
 ___
 ### SetSprite () {: aria-label='Functions' }
-#### void SetSprite ( [Sprite](../Sprite.md) Sprite ) {: .copyable aria-label='Functions' }   
+#### void SetSprite ( [Sprite](../Sprite.md) Sprite ) {: .copyable aria-label='Functions' }
+#### void SetSprite ( [Sprite](../Sprite.md) Sprite, string LayerName, bool UseOverlay ) {: .copyable aria-label='Functions' }
+#### void SetSprite ( [Sprite](../Sprite.md) Sprite, int LayerID, bool UseOverlay ) {: .copyable aria-label='Functions' } 
 
 ___
 ### SetUnkBool () {: aria-label='Functions' }

--- a/docs/docs/renderer/Point.md
+++ b/docs/docs/renderer/Point.md
@@ -8,7 +8,7 @@ Used for [Beam](Beam.md).
 
 ## Constructors
 ### Beam () {: aria-label='Constructors' }
-#### [Point](Point.md) Point ( [Vector](../Vector.md) Position, float SpritesheetCoordinate, float Width = 1.0, [Color](../Color.md) PointColor = Default ) {: .copyable aria-label='Constructors' }
+#### [Point](Point.md) Point ( [Vector](../Vector.md) Position, float SpritesheetCoordinate, float Width = 1.0 ) {: .copyable aria-label='Constructors' }
 
 ???+ info "Info"
     `SpritesheetCoordinate` is, to our current understanding, the `Y` position of the spritesheet that should be drawn by the time this Point is reached. For example, two points of `0` and `64` SpritesheetCoordinate will render the spritesheet starting from `y 0` to `y 64`, while an additional third point of `0` will draw it in reverse from `y 64` to `y 0`.
@@ -18,10 +18,6 @@ ___
 
 ## Functions
 
-### GetColor () {: aria-label='Functions' }
-#### [Color](..Color.md) GetColor ( ) {: .copyable aria-label='Functions' }   
-
-___
 ### GetSpritesheetCoordinate  () {: aria-label='Functions' }
 #### float GetSpritesheetCoordinate ( ) {: .copyable aria-label='Functions' }   
 
@@ -32,10 +28,6 @@ ___
 ___
 ### GetPosition () {: aria-label='Functions' }
 #### [Vector](../Vector.md) GetPosition ( ) {: .copyable aria-label='Functions' }   
-
-___
-### SetColor () {: aria-label='Functions' }
-#### void SetColor ( [Color](..Color.md) PointColor ) {: .copyable aria-label='Functions' }   
 
 ___
 ### SetSpritesheetCoordinate () {: aria-label='Functions' }

--- a/libzhl/functions/BeamRenderer.zhl
+++ b/libzhl/functions/BeamRenderer.zhl
@@ -14,16 +14,16 @@ static void BeamRenderer::End();
 // the deque insists that Point must be defined before BeamRenderer
 struct BeamRenderer depends (ANM2, Point) {
 	{{
-		BeamRenderer(unsigned int layer, bool useOverlayData, bool unkBool) : _layer(layer), _useOverlayData(useOverlayData), _unkBool(unkBool) {}
+		BeamRenderer(ANM2& anm2, unsigned int layer, bool useOverlayData, bool unkBool) : _anm2(anm2), _layer(layer), _useOverlayData(useOverlayData), _unkBool(unkBool) {}
 	
 		inline ANM2* GetANM2() { return &this->_anm2; }
 		inline unsigned int* GetLayer() { return &this->_layer; }
 		inline bool* GetUseOverlay() { return &this->_useOverlayData; }
 		inline bool* GetUnkBool() { return &this->_unkBool; } 
 	}}
-	ANM2 _anm2 : 0x0;
-	unsigned int _layer : 0x114;
-	bool _useOverlayData : 0x118;
-	bool _unkBool : 0x119;
-	deque_Point _points : 0x11c;
-} : 0x130;
+	ANM2& _anm2 : 0x0;
+	unsigned int _layer : 0x4;
+	bool _useOverlayData : 0x8;
+	bool _unkBool : 0x9;
+	deque_Point _points : 0xc;
+} : 0x30;

--- a/libzhl/functions/BeamRenderer.zhl
+++ b/libzhl/functions/BeamRenderer.zhl
@@ -23,5 +23,5 @@ struct BeamRenderer depends (ANM2) {
 	unsigned int _layer : 0x114;
 	bool _useOverlayData : 0x118;
 	bool _unkBool : 0x119;
-	vector_Point _points : 0x11c;
-} : 0x128;
+	deque_Point _points : 0x11c;
+} : 0x130;

--- a/libzhl/functions/BeamRenderer.zhl
+++ b/libzhl/functions/BeamRenderer.zhl
@@ -10,7 +10,9 @@ static void BeamRenderer::Add(Vector *point, ColorMod * color, float spritesheet
 "538bdc83ec0883e4f883c404558b6b??896c24??8bec6aff68????????64a1????????505381ecb0010000a1????????33c58945??5657508d45??64a3????????8b3d":
 static void BeamRenderer::End();
 
-struct BeamRenderer depends (ANM2) {
+// we don't actually use Point here, just a deque, but for some reason
+// the deque insists that Point must be defined before BeamRenderer
+struct BeamRenderer depends (ANM2, Point) {
 	{{
 		BeamRenderer(unsigned int layer, bool useOverlayData, bool unkBool) : _layer(layer), _useOverlayData(useOverlayData), _unkBool(unkBool) {}
 	

--- a/libzhl/functions/ExtraTypes
+++ b/libzhl/functions/ExtraTypes
@@ -60,8 +60,8 @@ TypeInfo vector_ColorParams {
     Align 4;
 };
 
-TypeInfo vector_Point {
-    Size 12;
+TypeInfo deque_Point {
+    Size 20;
     Align 4;
 };
 

--- a/libzhl/functions/Global.zhl
+++ b/libzhl/functions/Global.zhl
@@ -48,7 +48,7 @@ struct IntPair {
 };
 
 // When adding typedefs, remember to define them in ExtraTypes!
-typedef std::vector<Point> vector_Point;
+typedef std::deque<Point> deque_Point;
 typedef std::vector<ColorParams> vector_ColorParams;
 typedef std::deque<Console_HistoryEntry> std_deque_console_historyentry;
 typedef std::set<int> std_set_int;

--- a/libzhl/functions/Point.zhl
+++ b/libzhl/functions/Point.zhl
@@ -1,12 +1,11 @@
 "558bec83ec10568bf1f30f1046":
 __thiscall void Point::UpdateNormal(Vector* unk);
 
-struct Point depends (Vector, ColorMod) {
+struct Point depends (Vector) {
 	{{
-		Point() : _pos(Vector()), _spritesheetCoordinate(0.0f), _width(1.0f), _color(ColorMod()) {}
-		Point(Vector const& pos, float spritesheetCoordinate, float width, ColorMod const& color) : _pos(pos), _spritesheetCoordinate(spritesheetCoordinate), _width(width), _color(color) {}
+		Point() : _pos(Vector()), _spritesheetCoordinate(0.0f), _width(1.0f) {}
+		Point(Vector const& pos, float spritesheetCoordinate, float width) : _pos(pos), _spritesheetCoordinate(spritesheetCoordinate), _width(width) {}
 	}}
 	Vector _pos : 0x0;
 	float _width : 0x8, _spritesheetCoordinate : 0xc;
-	ColorMod _color : 0x10;
-} : 0x3c;
+} : 0x10;

--- a/repentogon/LuaInterfaces/LuaBeamRenderer.cpp
+++ b/repentogon/LuaInterfaces/LuaBeamRenderer.cpp
@@ -70,7 +70,6 @@ LUA_FUNCTION(Lua_BeamAdd) {
 }
 
 LUA_FUNCTION(Lua_BeamRender) {
-	__debugbreak();
 	BeamRenderer* beam = lua::GetUserdata<BeamRenderer*>(L, 1, lua::metatables::BeamMT);
 	int8_t error = -1;
 	bool clearPoints = lua::luaL_optboolean(L, 2, true);

--- a/repentogon/LuaInterfaces/LuaSprite.cpp
+++ b/repentogon/LuaInterfaces/LuaSprite.cpp
@@ -325,7 +325,7 @@ LUA_FUNCTION(Lua_LayerStateGetWrapTMode)
 LUA_FUNCTION(Lua_LayerStateSetWrapSMode)
 {
 	LayerState* layerState = *lua::GetUserdata<LayerState**>(L, 1, lua::metatables::LayerStateMT);
-	layerState->_wrapSMode = luaL_checkinteger(L, 2);
+	layerState->_wrapSMode = (int)luaL_checkinteger(L, 2);
 
 	return 0;
 }
@@ -333,7 +333,7 @@ LUA_FUNCTION(Lua_LayerStateSetWrapSMode)
 LUA_FUNCTION(Lua_LayerStateSetWrapTMode)
 {
 	LayerState* layerState = *lua::GetUserdata<LayerState**>(L, 1, lua::metatables::LayerStateMT);
-	layerState->_wrapTMode = luaL_checkinteger(L, 2);
+	layerState->_wrapTMode = (int)luaL_checkinteger(L, 2);
 
 	return 0;
 }


### PR DESCRIPTION
In preparation for a cord reimplementation, I've decided to optimize certain aspects of Beam and Point.

1. Beam no longer holds its own copy of Sprite. This will require Sprite objects used for Beam to be in the same "scope", but shaves off a nice 0x100 bytes per Beam.
2. Beam now stores its Points in a deque. This doesn't have much effect currently, but will be an important optimization for cords.
3. Points no longer hold a Color object. This saves 0x2c per Point, which _will_ add up as more Points get used for cords. This does also mean that Beams can no longer be colored, but I intend to look into ways to add this back without storing a bunch of usually default Colors.