### PR TITLE
TryUnlock optional arg

### DIFF
--- a/repentogon/LuaInterfaces/LuaPersistentGameData.cpp
+++ b/repentogon/LuaInterfaces/LuaPersistentGameData.cpp
@@ -3,6 +3,7 @@
 #include "HookSystem.h"
 #include "../Patches/XMLData.h"
 #include "../Patches/ChallengesStuff.h"
+#include "../Patches/AchievementsStuff.h"
 
 static const unsigned int PGD_COUNTER_MAX = 495;
 static const unsigned int COLLECTIBLE_MAX = 732;
@@ -20,8 +21,16 @@ LUA_FUNCTION(Lua_PGDTryUnlock)
 {
 	PersistentGameData* pgd = *lua::GetUserdata<PersistentGameData**>(L, 1, lua::metatables::PersistentGameDataMT);
 	int unlock = (int)luaL_checkinteger(L, 2);
+	if (lua_isboolean(L, 3) && lua_toboolean(L, 3)) {
+		nextSkipAchiev = unlock;
+	}
+
 
 	bool success = pgd->TryUnlock(unlock);
+	if (!success) {
+		// It failed, so reset state manually
+		nextSkipAchiev = -1;
+;	}
 	lua_pushboolean(L, success);
 	return 1;
 }

--- a/repentogon/Patches/AchievementsStuff.cpp
+++ b/repentogon/Patches/AchievementsStuff.cpp
@@ -133,10 +133,6 @@ HOOK_METHOD(PersistentGameData, TryUnlock, (int achieveemntid) -> bool) {
 		else {
 			if (nextSkipAchiev == achieveemntid) {
 				nextSkipAchiev = -1;
-				printf("[Achiev] Modded popup prevented due to optional arg in TryUnlock\n");
-			}
-			else {
-				printf("[Achiev] Modded popup prevented due to pops disabled or hidden achiev \n");
 			}
 		}
 		return true;

--- a/repentogon/Patches/AchievementsStuff.cpp
+++ b/repentogon/Patches/AchievementsStuff.cpp
@@ -49,6 +49,8 @@ string achivjsonpath;
 
 bool sourceswithachievset = false;
 
+int nextSkipAchiev = -1;
+
 int dummyachiev = -1;
 bool achievdone = false;
 bool blocksteam = false;
@@ -108,7 +110,7 @@ HOOK_METHOD(PersistentGameData, TryUnlock, (int achieveemntid) -> bool) {
 		Achievements[achievid] = 2; //2 is for notified, 1 is accomplished, <1 is in progress
 		RunTrackersForAchievementCounter(achieveemntid);
 		SaveAchieveemntsToJson();
-		if (((modachiev.find("hidden") == modachiev.end()) || (modachiev["hidden"] == "false")) && g_Manager->GetOptions()->PopUpsEnabled()) { //it is prevented even without this check, but theres no point in doing the hackies if thats the case.
+		if (nextSkipAchiev != achieveemntid && ((modachiev.find("hidden") == modachiev.end()) || (modachiev["hidden"] == "false")) && g_Manager->GetOptions()->PopUpsEnabled()) { //it is prevented even without this check, but theres no point in doing the hackies if thats the case.
 			pendingachievs.push(achieveemntid);
 			if (dummyachiev < 0) {
 				dummyachiev = 2;
@@ -128,7 +130,15 @@ HOOK_METHOD(PersistentGameData, TryUnlock, (int achieveemntid) -> bool) {
 			blocksteam = false;
 			this->achievements[dum] = had;
 		}
-		else { printf("[Achiev] Modded popup prevented due to pops disabled or hidden achiev \n"); }
+		else {
+			if (nextSkipAchiev == achieveemntid) {
+				nextSkipAchiev = -1;
+				printf("[Achiev] Modded popup prevented due to optional arg in TryUnlock\n");
+			}
+			else {
+				printf("[Achiev] Modded popup prevented due to pops disabled or hidden achiev \n");
+			}
+		}
 		return true;
 	}
 	return false;

--- a/repentogon/Patches/AchievementsStuff.h
+++ b/repentogon/Patches/AchievementsStuff.h
@@ -527,6 +527,7 @@ extern unordered_map<int, unordered_map<int, vector<int>> > EventCounterListener
 extern unordered_map<int, vector<int>> AchievementListeners; //achievementid - achievements to complete
 extern unordered_map<tuple<int, int, int>, unordered_map<int, vector<int>>> BossDeathListeners;
 extern string achivjsonpath;
+extern int nextSkipAchiev; // Modded achievement to skip if second arg of TryUnlock is true
 
 extern int toint(const string &str);
 


### PR DESCRIPTION
Supply `true` as the second argument when unlocking a modded achievement to prevent the achievement paper popup.