### PR TITLE
kill off changelog_official_text.lua, part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,6 @@ jobs:
         submodules: 'true'
         fetch-depth: 0
           
-    - name: Generate changelog
-      run: |
-        echo "return [[" > ${{github.workspace}}/repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        git log -n 10 --pretty=format:"%h (%an)%n* %s%n/fade/%b%n/newline/" >> ${{github.workspace}}/repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "]]" >> ${{github.workspace}}/repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "Resulting lua file:"
-        type ${{github.workspace}}/repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "#pragma once" > ${{github.workspace}}/repentogon/Version.h
-        $sha = git rev-parse --short HEAD
-        echo "#define VERSION `"nightly-$sha`"" >> ${{github.workspace}}/repentogon/Version.h
-        (gc ${{github.workspace}}/repentogon/resources/scripts/main_ex.lua) -replace 'dev build', "nightly-$sha" | Out-File -encoding ASCII ${{github.workspace}}/repentogon/resources/scripts/main_ex.lua
-        (gc ${{github.workspace}}/launcher/Updater.cpp) -replace 'std::string version = "dev build";', 'std::string version = "nightly-$sha";' | Out-File -encoding ASCII ${{github.workspace}}/launcher/Updater.cpp
-
-
-
     - name: Configure CMake
       run: cmake -G "Visual Studio 17 2022" -A "Win32" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
@@ -56,6 +41,7 @@ jobs:
         mv zhlREPENTOGON.dll artifact
         mv Lua5.4.dll artifact
         mv freetype.dll artifact
+        cp ${{github.workspace}}/changelog.txt artifact/rgon_changelog.txt
         
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
       with:
         submodules: 'true'
         fetch-depth: 0
+
+    - name: Generate version info
+      run: |
+        echo "#pragma once" > ${{github.workspace}}/repentogon/Version.h
+        $sha = git rev-parse --short HEAD
+        echo "#define VERSION `"nightly-$sha`"" >> ${{github.workspace}}/repentogon/Version.h
+        (gc ${{github.workspace}}/repentogon/resources/scripts/main_ex.lua) -replace 'dev build', "nightly-$sha" | Out-File -encoding ASCII ${{github.workspace}}/repentogon/resources/scripts/main_ex.lua
+        (gc ${{github.workspace}}/launcher/Updater.cpp) -replace 'std::string version = "dev build";', 'std::string version = "nightly-$sha";' | Out-File -encoding ASCII ${{github.workspace}}/launcher/Updater.cpp
           
     - name: Configure CMake
       run: cmake -G "Visual Studio 17 2022" -A "Win32" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,7 @@ build_script:
 
     git submodule update
 
-    echo "return [[" | Out-File -encoding ASCII repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        Get-Content changelog.txt -Raw | Add-Content repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "]]" | Add-Content repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "Resulting lua file:"
-        type repentogon/resources/scripts/repentogon_extras/changelog_official_text.lua
-        echo "#pragma once" | Out-File -encoding ASCII repentogon/Version.h
+    echo "#pragma once" | Out-File -encoding ASCII repentogon/Version.h
         $version = Get-Content version.txt -Raw
         echo "#define VERSION `"$version`"" | Add-Content repentogon/Version.h
         (gc repentogon/resources/scripts/main_ex.lua) -replace 'dev build', "$version" | Out-File -encoding ASCII repentogon/resources/scripts/main_ex.lua
@@ -36,6 +31,7 @@ build_script:
         mv zhlREPENTOGON.dll artifact
         mv Lua5.4.dll artifact
         mv freetype.dll artifact
+        cp ../../changelog.txt artifact/rgon_changelog.txt
 
     cd artifact
 


### PR DESCRIPTION
This pull request makes our CI jobs copy the changelog txt directly to the root of the project, therefore officially killing off the bad lua-side hack