### PR TITLE
Console Autofill Limit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v1.x.x -
 Additions:
+* Add new Vanilla Tweaks option "Console Autofill Limit", which determines the number of autocomplete items that are displayed in the debug console.
 * Level:
 	- CanPlaceRoom(RoomConfigRoom, int GridIndex, int Dimension = -1, bool AllowMultipleDoors = true, bool AllowSpecialNeighbors = false, bool AllowNoNeighbors = false)
 		Returns true if the room would be able to fit at this location.

--- a/repentogon/ImGuiFeatures/ConsoleMega.h
+++ b/repentogon/ImGuiFeatures/ConsoleMega.h
@@ -6,6 +6,7 @@
 #include "LuaCore.h"
 #include "UnifontSupport.h"
 #include "Lang.h"
+#include "../REPENTOGONOptions.h"
 
 #include <sstream>
 #include <cctype>
@@ -1212,7 +1213,7 @@ struct ConsoleMega : ImGuiWindowObject {
                             [](unsigned char c) { return std::tolower(c); });
 
                         if (lowerText.rfind(lowerBuf, 0) == 0 || lowerDesc.find(lowerDescBuf) != std::string::npos) {
-                            if (autocompleteBuffer.size() > 10) {       //autocomplete result cap is defined here
+                            if (autocompleteBuffer.size() > repentogonOptions.consoleAutofillLimit) {       //autocomplete result cap is defined here
                                 break;
                             };
                             autocompleteBuffer.push_back(entry);

--- a/repentogon/ImGuiFeatures/GameOptions.h
+++ b/repentogon/ImGuiFeatures/GameOptions.h
@@ -323,12 +323,19 @@ struct GameOptionsWindow : ImGuiWindowObject {
                         ImGui::SameLine();
                         HelpMarker(LANG.OPT_REPENTOGON_MARSDOUBLETAP_MARK);
                         AddResetButton(++resetCounter, repentogonOptions.marsDoubleTapWindow, 10);
+
+                        AddNewTableRow();
+                        ImGui::SliderInt(LANG.OPT_REPENTOGON_CONSOLE_AUTOFILL_LIMIT, &repentogonOptions.consoleAutofillLimit, 1, 1000, "%d", ImGuiSliderFlags_AlwaysClamp);
+                        ImGui::SameLine();
+                        HelpMarker(LANG.OPT_REPENTOGON_CONSOLE_AUTOFILL_LIMIT_MARK);
+                        AddResetButton(++resetCounter, repentogonOptions.consoleAutofillLimit, 10);
+
                         AddNewTableRow();
                         ImGui::Checkbox(LANG.OPT_REPENTOGON_FILE_MAP, &repentogonOptions.fileMap);
                         ImGui::SameLine();
                         HelpMarker(LANG.OPT_REPENTOGON_FILE_MAP_MARK);
                         AddResetButton(++resetCounter, repentogonOptions.fileMap, true);
-   
+
                         AddNewTableRow();
                         ImGui::Checkbox(LANG.OPT_REPENTOGON_DEBUG_FIND_IN_RADIUS, &repentogonOptions.renderDebugFindInRadius);
                         ImGui::SameLine();

--- a/repentogon/ImGuiFeatures/Localization/en_us.inl
+++ b/repentogon/ImGuiFeatures/Localization/en_us.inl
@@ -312,6 +312,8 @@ I(OPT_REPENTOGON_PREVENT_MOD_UPDATES, u8"Prevent mod updates")
 I(OPT_REPENTOGON_PREVENT_MOD_UPDATES_MARK, u8"The game will skip syncing workshop mods. Useful for preventing changes to the mod folder during mod development.")
 I(OPT_REPENTOGON_MARSDOUBLETAP, u8"Mars Double Tap Window")
 I(OPT_REPENTOGON_MARSDOUBLETAP_MARK, u8"Sets the window of time to double-tap a movement input to dash with Mars.")
+I(OPT_REPENTOGON_CONSOLE_AUTOFILL_LIMIT, u8"Command Autofill Limit")
+I(OPT_REPENTOGON_CONSOLE_AUTOFILL_LIMIT_MARK, u8"Sets the limit of how many items are displayed in the Debug Console when typing a command. Increasing this to a large number can cause performance to degrade while typing in the console.")
 
 I(OPT_REPENTOGON_FILE_MAP, u8"Enable modded file map generation")
 I(OPT_REPENTOGON_FILE_MAP_MARK, u8"Preemptively checks all modded files for faster game start and less stutters. Disable and report to us if you have issues with modded assets loading.")

--- a/repentogon/REPENTOGONOptions.h
+++ b/repentogon/REPENTOGONOptions.h
@@ -37,6 +37,7 @@ struct REPENTOGONOptions {
 			ini["VanillaTweaks"]["FastLasers"] = "0";
 			ini["VanillaTweaks"]["InterpolV2"] = "0";
 			ini["VanillaTweaks"]["MarsDoubleTapWindow"] = "10";
+			ini["VanillaTweaks"]["ConsoleAutofillLimit"] = "10";
 			ini["internal"]["DidModReset"] = "0";
 			ini["internal"]["EnableUnifont"] = "1";
 			ini["internal"]["UnifontRenderMode"] = "0";
@@ -53,6 +54,7 @@ struct REPENTOGONOptions {
 		hushPanicStateFix = defstoi(ini["VanillaTweaks"]["HushPanicStateFix"],1);
 		keyMasterDealChance = defstoi(ini["VanillaTweaks"]["KeyMasterDealChance"],0);
 		quickRoomClear = defstoi(ini["VanillaTweaks"]["QuickRoomClear"], 0);
+		consoleAutofillLimit = defstoi(ini["VanillaTweaks"]["ConsoleAutofillLimit"], 10);
 		statHUDPlanetarium = defstoi(ini["VanillaTweaks"]["StatHUDPlanetarium"], 1);
 		skipIntro = defstoi(ini["VanillaTweaks"]["SkipIntro"], 0);
 		preventModUpdates = defstoi(ini["VanillaTweaks"]["PreventModUpdates"], 0);
@@ -104,6 +106,7 @@ struct REPENTOGONOptions {
 		Write("VanillaTweaks", "FastLasers", fastLasers);
 		Write("VanillaTweaks", "InterpolV2", interpolV2);
 		Write("VanillaTweaks", "MarsDoubleTapWindow", marsDoubleTapWindow);
+		Write("VanillaTweaks", "ConsoleAutofillLimit", consoleAutofillLimit);
 		Write("internal",	   "EnableUnifont",		   enableUnifont);
 		Write("internal",	   "UnifontRenderMode",	   unifontRenderMode);
 		Write("internal", "LastSaveFile", lastSaveFile);
@@ -128,6 +131,7 @@ struct REPENTOGONOptions {
 	int marsDoubleTapWindow;
 	bool fileMap;
 	int imGuiScale;
+	int consoleAutofillLimit;
 	std::string optionsPath;
 	bool renderDebugFindInRadius;
 };


### PR DESCRIPTION
Adds a new option that lets you set a limit on how many autocomplete items are displayed in the Debug Console.