### PR TITLE
vanilla tweaks: add a launch flag to skip archived file checksumming

### DIFF
--- a/repentogon/Patches/ASMPatches.cpp
+++ b/repentogon/Patches/ASMPatches.cpp
@@ -184,6 +184,10 @@ void PerformASMPatches() {
 		ZHL::Log("[ERROR] Error while fixing the Berserk + Spirit Shackles crash\n");
 	}
 
+	if (!ASMPatches::SkipArchiveChecksums()) {
+		ZHL::Log("[ERROR] Error while applying an archive checksum skip\n");
+	};
+
 	// This patch needs to be remade to include a toggle setting and fix glowing hourglass and the day before a release isn't the time for that
 
 	//if (!ASMPatches::FixHushFXVeins()) {

--- a/repentogon/Patches/ASMPatches/ASMTweaks.h
+++ b/repentogon/Patches/ASMPatches/ASMTweaks.h
@@ -4,6 +4,7 @@ namespace ASMPatches {
 	bool FixGodheadEntityPartition();
 	bool FixTearDetonatorEntityList();
 	bool FixHushFXVeins();
+	bool SkipArchiveChecksums();
 
 	namespace BerserkSpiritShacklesCrash {
 		bool Patch();


### PR DESCRIPTION
This pull request provides a new `-skipchecksum` launch parameter which makes the game skip a block of code for performing checksum generation and validation, leading to a massive startup time boost. It is opt-in to avoid potential issues that could arise from a checksum mismatch.
Archive read speed comparison on my machine with NVMe SSD (using times provided by the log entry, avg over three consecutive launches):
without the flag - (8930+9035+7869)/3 -> 8611ms
with the flag - (1270+1265+1262)/3 -> 1266ms

Shaving seven whole seconds is rather huge I'd say.