### PR TITLE
imgui: downgrade to opengl2 impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ target_compile_definitions(freetype PRIVATE FT2_BUILD_LIBRARY PRIVATE DLL_EXPORT
 FILE(GLOB IMGUI_SRC ${CMAKE_SOURCE_DIR}/libs/imgui/*.cpp)
 FILE(GLOB IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
 set(IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
-add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
+add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.h ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3_loader.h ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
 target_include_directories(imgui PUBLIC "${CMAKE_SOURCE_DIR}/libs/freetype/include")
 target_compile_options(imgui PUBLIC "/MD")
 target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_FREETYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ target_compile_definitions(freetype PRIVATE FT2_BUILD_LIBRARY PRIVATE DLL_EXPORT
 FILE(GLOB IMGUI_SRC ${CMAKE_SOURCE_DIR}/libs/imgui/*.cpp)
 FILE(GLOB IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
 set(IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
-add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.h ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3_loader.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
+add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
 target_include_directories(imgui PUBLIC "${CMAKE_SOURCE_DIR}/libs/freetype/include")
 target_compile_options(imgui PUBLIC "/MD")
 target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_FREETYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ target_compile_definitions(freetype PRIVATE FT2_BUILD_LIBRARY PRIVATE DLL_EXPORT
 FILE(GLOB IMGUI_SRC ${CMAKE_SOURCE_DIR}/libs/imgui/*.cpp)
 FILE(GLOB IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
 set(IMGUI_BACKENDS_DIR ${CMAKE_SOURCE_DIR}/libs/imgui/backends/)
-add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3.h ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl3_loader.h ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
+add_library(imgui ${IMGUI_SRC} ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.h ${CMAKE_SOURCE_DIR}/libs/imgui/misc/freetype/imgui_freetype.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.cpp ${IMGUI_BACKENDS_DIR}/imgui_impl_opengl2.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.h ${IMGUI_BACKENDS_DIR}/imgui_impl_win32.cpp)
 target_include_directories(imgui PUBLIC "${CMAKE_SOURCE_DIR}/libs/freetype/include")
 target_compile_options(imgui PUBLIC "/MD")
 target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_FREETYPE)

--- a/repentogon/ImGuiFeatures/CustomImGui.h
+++ b/repentogon/ImGuiFeatures/CustomImGui.h
@@ -8,6 +8,10 @@
 
 #include "LuaCore.h"
 
+extern HGLRC imguiRenderContext;
+extern HGLRC oldRenderContext;
+extern HDC deviceContext;
+
 extern int handleWindowFlags(int flags);
 extern ImGuiKey AddChangeKeyButton(bool isController, bool& wasPressed);
 extern void AddWindowContextMenu(bool* pinned);

--- a/repentogon/ImGuiFeatures/ImGui.cpp
+++ b/repentogon/ImGuiFeatures/ImGui.cpp
@@ -486,14 +486,15 @@ void __stdcall RunImGui(HDC hdc) {
 	WINMouseWheelMove_Vert = 0; // Windows doesn't call callbacks all the time, so this values is "sticking"
 	WINMouseWheelMove_Hori = 0;
 	deviceContext = hdc;
-
+	oldRenderContext = wglGetCurrentContext();
 	if (!imguiInitialized) {
 		HWND window = WindowFromDC(hdc);
 		windowProc = (WNDPROC)SetWindowLongPtr(window,
 			GWLP_WNDPROC, (LONG_PTR)windowProc_hook);
 		imguiRenderContext = wglCreateContext(hdc);
+		wglMakeCurrent(hdc, imguiRenderContext);
 		ImGui::CreateContext();
-		ImGui_ImplWin32_Init(window);
+		ImGui_ImplWin32_InitForOpenGL(window);
 		ImGui_ImplOpenGL2_Init();
 		ImGui::StyleColorsDark();
 		ImGui::GetStyle().AntiAliasedFill = false;
@@ -557,16 +558,15 @@ void __stdcall RunImGui(HDC hdc) {
 		cfg.GlyphOffset = ImVec2(0, 1.5f); // move icon a bit down to center them in objects
 		cfg.RasterizerDensity = 5; // increase DPI, to make icons look less fucked by the rasterizer
 		io.Fonts->AddFontFromFileTTF("resources-repentogon\\fonts\\Font Awesome 6 Free-Solid-900.otf", font_base_size, &cfg, icon_ranges);
-	
+
 		imguiInitialized = true;
 		ImGui::GetIO().FontAllowUserScaling = true;
 		logViewer.AddLog("[REPENTOGON]", "Initialized Dear ImGui v%s\n", IMGUI_VERSION);
 		printf("[REPENTOGON] Dear ImGui v%s initialized! Any further logs can be seen in the in-game log viewer.\n", IMGUI_VERSION);
 	}
-
-	oldRenderContext = wglGetCurrentContext();
-	wglMakeCurrent(hdc, imguiRenderContext);
-
+	else {
+		wglMakeCurrent(hdc, imguiRenderContext);
+	};
 	ImGui_ImplOpenGL2_NewFrame();
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();

--- a/repentogon/ImGuiFeatures/ImGui.cpp
+++ b/repentogon/ImGuiFeatures/ImGui.cpp
@@ -22,7 +22,7 @@
 
 #include "imgui.h"
 #include "imgui_freetype.h"
-#include "imgui_impl_opengl3.h"
+#include "imgui_impl_opengl2.h"
 #include "imgui_impl_win32.h"
 #include "../MiscFunctions.h"
 #include "../REPENTOGONOptions.h"
@@ -475,8 +475,10 @@ void RenderLuamodErrorPopup() {
 //luamod error popup end
 
 ImFont* imFontUnifont = NULL;
+HGLRC imguiRenderContext=NULL;
 
 void __stdcall RunImGui(HDC hdc) {
+	HGLRC oldcontext;
 	static std::map<int, ImFont*> fonts;
 
 	static float unifont_global_scale = 1;
@@ -487,10 +489,10 @@ void __stdcall RunImGui(HDC hdc) {
 		HWND window = WindowFromDC(hdc);
 		windowProc = (WNDPROC)SetWindowLongPtr(window,
 			GWLP_WNDPROC, (LONG_PTR)windowProc_hook);
-
+		imguiRenderContext = wglCreateContext(hdc);
 		ImGui::CreateContext();
 		ImGui_ImplWin32_Init(window);
-		ImGui_ImplOpenGL3_Init();
+		ImGui_ImplOpenGL2_Init();
 		ImGui::StyleColorsDark();
 		ImGui::GetStyle().AntiAliasedFill = false;
 		ImGui::GetStyle().AntiAliasedLines = false;
@@ -560,7 +562,10 @@ void __stdcall RunImGui(HDC hdc) {
 		printf("[REPENTOGON] Dear ImGui v%s initialized! Any further logs can be seen in the in-game log viewer.\n", IMGUI_VERSION);
 	}
 
-	ImGui_ImplOpenGL3_NewFrame();
+	oldcontext = wglGetCurrentContext();
+	wglMakeCurrent(hdc, imguiRenderContext);
+
+	ImGui_ImplOpenGL2_NewFrame();
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
 	UpdateImGuiSettings();
@@ -630,7 +635,9 @@ void __stdcall RunImGui(HDC hdc) {
 	ImGui::Render();
 
 	// Draw the overlay
-	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+	ImGui_ImplOpenGL2_RenderDrawData(ImGui::GetDrawData());
+
+	wglMakeCurrent(hdc, oldcontext);
 }
 
 

--- a/repentogon/ImGuiFeatures/ImGui.cpp
+++ b/repentogon/ImGuiFeatures/ImGui.cpp
@@ -23,7 +23,6 @@
 #include "imgui.h"
 #include "imgui_freetype.h"
 #include "imgui_impl_opengl2.h"
-#include "imgui_impl_opengl3.h"
 #include "imgui_impl_win32.h"
 #include "../MiscFunctions.h"
 #include "../REPENTOGONOptions.h"
@@ -31,8 +30,6 @@
 // this blogpost https://werwolv.net/blog/dll_injection was a big help, thanks werwolv!
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
-
-
 
 HWND window;
 WNDPROC windowProc;
@@ -480,20 +477,6 @@ void RenderLuamodErrorPopup() {
 ImFont* imFontUnifont = NULL;
 HGLRC imguiRenderContext=NULL;
 
-typedef bool (*ImGui_impl_Init)(const char* glsl_version);	//function prototypes for pointers
-typedef void (*ImGui_impl_NewFrame)();
-typedef void (*ImGui_impl_RenderDrawData)(ImDrawData *imdrawdata);
-
-bool imgui_gl2_init_wrapper(const char* glsl_version) {
-	return ImGui_ImplOpenGL2_Init();
-};
-
-ImGui_impl_Init imgui_init = &imgui_gl2_init_wrapper;
-ImGui_impl_NewFrame imgui_newframe = &ImGui_ImplOpenGL2_NewFrame;
-ImGui_impl_RenderDrawData imgui_renderdrawdata = &ImGui_ImplOpenGL2_RenderDrawData;
-
-
-
 void __stdcall RunImGui(HDC hdc) {
 	HGLRC oldcontext;
 	static std::map<int, ImFont*> fonts;
@@ -506,19 +489,10 @@ void __stdcall RunImGui(HDC hdc) {
 		HWND window = WindowFromDC(hdc);
 		windowProc = (WNDPROC)SetWindowLongPtr(window,
 			GWLP_WNDPROC, (LONG_PTR)windowProc_hook);
-		char* glVer = (char*)glGetString(GL_VERSION); // ver = "3.2.0"
-
-		int glMajorVer = glVer[0] - '0';
-		printf("Reported OpenGL: %s\nParsed major version is %d\n", glVer,glMajorVer);
-		if (glMajorVer > 2) {	//if opengl > 2 then it can use opengl 3.0 impl of imgui
-			imgui_init = &ImGui_ImplOpenGL3_Init;
-			imgui_newframe = &ImGui_ImplOpenGL3_NewFrame;
-			imgui_renderdrawdata = &ImGui_ImplOpenGL3_RenderDrawData;
-		};
-//		imguiRenderContext = wglCreateContext(hdc);
+		imguiRenderContext = wglCreateContext(hdc);
 		ImGui::CreateContext();
 		ImGui_ImplWin32_Init(window);
-		imgui_init(nullptr);
+		ImGui_ImplOpenGL2_Init();
 		ImGui::StyleColorsDark();
 		ImGui::GetStyle().AntiAliasedFill = false;
 		ImGui::GetStyle().AntiAliasedLines = false;
@@ -589,8 +563,9 @@ void __stdcall RunImGui(HDC hdc) {
 	}
 
 	oldcontext = wglGetCurrentContext();
-	//wglMakeCurrent(hdc, imguiRenderContext);
-	imgui_newframe();
+	wglMakeCurrent(hdc, imguiRenderContext);
+
+	ImGui_ImplOpenGL2_NewFrame();
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
 	UpdateImGuiSettings();
@@ -660,8 +635,9 @@ void __stdcall RunImGui(HDC hdc) {
 	ImGui::Render();
 
 	// Draw the overlay
-	imgui_renderdrawdata(ImGui::GetDrawData());
-//	wglMakeCurrent(hdc, oldcontext);
+	ImGui_ImplOpenGL2_RenderDrawData(ImGui::GetDrawData());
+
+	wglMakeCurrent(hdc, oldcontext);
 }
 
 

--- a/repentogon/Patches/ASMPatches.cpp
+++ b/repentogon/Patches/ASMPatches.cpp
@@ -193,7 +193,7 @@ void PerformASMPatches() {
 	ASMPatchesForCustomItemPools();
 	ExtraASMPatchesForCustomItemPools();
 	ASMPatchesForCardsExtras();
-	HookImGui();
+//	HookImGui();		//switched to wglswapbuffers for now
 
 	// Sprite
 	ASMPatchesForANM2Extras();

--- a/repentogon/Patches/ConsoleHooks.cpp
+++ b/repentogon/Patches/ConsoleHooks.cpp
@@ -5,6 +5,7 @@
 #include "LuaCore.h"
 #include "../Patches/ModReloading.h"
 #include "../REPENTOGONFileMap.h"
+#include "../ImGuiFeatures/CustomImGui.h"
 
 #include <filesystem>
 #include <iostream> 
@@ -87,6 +88,11 @@ HOOK_METHOD(Console, RunCommand, (std::string& in, std::string* out, Entity_Play
     // Normally, the console explicitly expects a player to run any command, and will actively try to find one (and will crash otherwise)
     // We ASM patched this out to let commands run on the menu, so now we reintroduce this ourselves.
     // If we're in-game, return the player; otherwise don't. Many functions obviously don't work out of the game! Throw errors for those.
+
+    if (oldRenderContext != 0) {
+        wglMakeCurrent(deviceContext, oldRenderContext);
+    };
+
     bool inGame = !(g_Manager->GetState() != 2 || !g_Game);
     std::string res;
 
@@ -209,4 +215,7 @@ HOOK_METHOD(Console, RunCommand, (std::string& in, std::string* out, Entity_Play
     }
 
     super(in, out, player);
+    if (oldRenderContext != 0) {
+        wglMakeCurrent(deviceContext, imguiRenderContext);
+    };
 }


### PR DESCRIPTION
This branch contains a commit that replaces the OpenGL 3 implementation of Dear ImGui with its' OpenGL 2 counterpart. May fix rendering issues on old GPUs. Not tested beyond confirmation of it functioning on OpenGL 4.6 capable hardware.