### PR TITLE
Localization modded resources/content support

### DIFF
--- a/libzhl/functions/KAGE_Filesys_FileManager.zhl
+++ b/libzhl/functions/KAGE_Filesys_FileManager.zhl
@@ -2,7 +2,7 @@
 static void KAGE_Filesys_FileManager::LoadArchiveFile(char *path, int unk1, unsigned short unk2);
 
 "558bec53568b75??5785f674":
-__thiscall char* KAGE_Filesys_FileManager::GetExpandedPath(char* filepath);
+__thiscall char* KAGE_Filesys_FileManager::GetExpandedPath(const char* filepath);
 
 struct KAGE_Filesys_FileManager  {
 };

--- a/libzhl/functions/Manager.zhl
+++ b/libzhl/functions/Manager.zhl
@@ -72,6 +72,9 @@ __thiscall void Manager::SetSaveSlot(unsigned int slot);
 "558bec518b0d????????8b55":
 __thiscall void Manager::ShowCutscene(uint32_t cutsceneID, bool shouldCleanup);
 
+"a1????????8b80????????83f813":
+static char* Manager::GetLanguage();
+
 struct Manager depends (Seeds, GameState, StringTable, PersistentGameData, NightmareScene, UnknownGameStartStruct, ModManager, ReferenceCounter_ImageBase, Cutscene, OptionsConfig, AchievementOverlay, SoundEffects, ItemConfig, EntityConfig, ANM2, Font, ChallengeParam, Music) { {{
 	inline int GetState() { return *(int*)((char*)this + 0x8); }
 	inline int* GetTestState() { return (int*)((char*)this + 0x8); }

--- a/libzhl/functions/ModEntry.zhl
+++ b/libzhl/functions/ModEntry.zhl
@@ -1,7 +1,7 @@
 
 
 "538bdc83ec0883e4f883c404558b6b??896c24??8bec6aff68????????64a1????????505383ec58a1????????33c58945??5657508d45??64a3????????8b51":
-__thiscall void ModEntry::GetContentPath(char**param_1,std_string* param_2); //doesnt work but it's a thing that exists and its at this sig, probably wrong params?
+__thiscall void ModEntry::GetContentPath(std_string& param_1,std_string& param_2); //doesnt work but it's a thing that exists and its at this sig, probably wrong params?
 
 "558bec6aff68????????64a1????????50b874000100":
 __thiscall void ModEntry::WriteMetadata();

--- a/libzhl/functions/ModManager.zhl
+++ b/libzhl/functions/ModManager.zhl
@@ -30,6 +30,7 @@ __thiscall void ModManager::Reset();
 "558bec83e4f851568bf1e8????????8bce":
 __thiscall void ModManager::TriggerResize();
 
-struct ModManager depends (ModEntry) {
+struct ModManager depends (ModEntry, RedirectedPath) {
 	vector_ModEntryPointer _mods : 0x0;
+	RedirectedPath* _redirectedPathsMap[32768] : 0xc;
 } : 0x2025c;

--- a/libzhl/functions/RedirectedPath.zhl
+++ b/libzhl/functions/RedirectedPath.zhl
@@ -1,0 +1,6 @@
+struct RedirectedPath depends (ModEntry) {
+	uint32_t _primaryHash : 0x0;
+	uint32_t _secondaryHash : 0x4;
+	ModEntry* _modEntry : 0x8;
+	std_string _filePath : 0xc;
+} : 0x24;

--- a/repentogon/Patches/ASMPatches.cpp
+++ b/repentogon/Patches/ASMPatches.cpp
@@ -26,6 +26,7 @@
 #include "ASMPatches/ASMRoom.h"
 #include "ASMPatches/ASMStatusEffects.h"
 #include "ASMPatches/ASMTweaks.h"
+#include "ASMPatches/ASMLocalization.h"
 
 #include "ASMPatcher.hpp"
 
@@ -193,6 +194,7 @@ void PerformASMPatches() {
 	ASMPatchesForCustomItemPools();
 	ExtraASMPatchesForCustomItemPools();
 	ASMPatchesForCardsExtras();
+	ASMPatchRedirectToLocalizationFolders();
 	HookImGui();
 
 	// Sprite

--- a/repentogon/Patches/ASMPatches/ASMLocalization.cpp
+++ b/repentogon/Patches/ASMPatches/ASMLocalization.cpp
@@ -1,0 +1,65 @@
+#include "ASMPatcher.hpp"
+#include "../ASMPatches.h"
+
+//to-do:
+/*
+* Add content support
+* Add DLC3 support for resources/content folders
+*/
+bool __stdcall TryToRedirectToLocalizedResources(std::string& resFileString, std::string& targetFile, ModEntry** modEntry, RedirectedPath* redirectPath) {
+	auto copyOfFileString = resFileString;
+	auto* manager = g_Manager->GetModManager();
+	auto* langCode = g_Manager->GetLanguage();
+
+	if (g_Manager->_stringTable.language == 0 || targetFile[0] == '\0') {
+		return false;
+	}
+
+	std::cout << targetFile << std::endl;
+	copyOfFileString = resFileString + "." + langCode + "/" + targetFile;
+
+	//printf("[RGON] kinda string filename: %s %s \n", copyOfFileString.c_str(), g_FileManager_kinda->GetExpandedPath(copyOfFileString.c_str()));
+
+	if (g_FileManager_kinda->GetExpandedPath(copyOfFileString.c_str()) != NULL) {
+		
+		resFileString = copyOfFileString;
+
+		redirectPath->_modEntry = *modEntry;
+		redirectPath->_filePath = resFileString;
+
+		std::cout << "[REPENTOGON] Patched " << resFileString << std::endl;
+
+		return true;
+	}
+
+
+	return false;
+}
+
+void ASMPatchRedirectToLocalizedResources() {
+	ASMPatch::SavedRegisters savedRegisters(ASMPatch::SavedRegisters::Registers::GP_REGISTERS, true);
+	ASMPatch patch;
+
+	SigScan signature("6a0668????????8d4d??c645??01");
+	signature.Scan();
+
+	void* addr = signature.GetAddress();
+	printf("[REPENTOGON] Patching ModManager::TryRedirectPath for testing at %p\n", addr);
+
+	patch.PreserveRegisters(savedRegisters)
+		.Push(ASMPatch::Registers::EBP, -0xa0) // RedirectedPath*
+		.Push(ASMPatch::Registers::ESI) // ModEntry
+		.Push(ASMPatch::Registers::EBP, -0xa4) // Target file
+		.Push(ASMPatch::Registers::EAX) //Mod resources folder
+		.AddInternalCall(TryToRedirectToLocalizedResources)
+		.AddBytes("\x84\xC0") // test al, al
+		.RestoreRegisters(savedRegisters)
+		.AddConditionalRelativeJump(ASMPatcher::CondJumps::JNE, (char*)addr + 0x2D4) // jump for true
+		.AddBytes(ByteBuffer().AddAny((char*)addr, 0x7))  // Restore the commands we overwrote
+		.AddRelativeJump((char*)addr + 0x7);
+	sASMPatcher.PatchAt(addr, &patch);
+}
+
+void ASMPatchRedirectToLocalizationFolders() {
+	ASMPatchRedirectToLocalizedResources();
+}

--- a/repentogon/Patches/ASMPatches/ASMLocalization.cpp
+++ b/repentogon/Patches/ASMPatches/ASMLocalization.cpp
@@ -1,9 +1,11 @@
+#include "IsaacRepentance.h"
+#include "HookSystem.h"
+
 #include "ASMPatcher.hpp"
 #include "../ASMPatches.h"
 
 //to-do:
 /*
-* Add content support
 * Add DLC3 support for resources/content folders
 */
 bool __stdcall TryToRedirectToLocalizedResources(std::string& resFileString, std::string& targetFile, ModEntry** modEntry, RedirectedPath* redirectPath) {
@@ -15,7 +17,7 @@ bool __stdcall TryToRedirectToLocalizedResources(std::string& resFileString, std
 		return false;
 	}
 
-	std::cout << targetFile << std::endl;
+	//std::cout << targetFile << std::endl;
 	copyOfFileString = resFileString + "." + langCode + "/" + targetFile;
 
 	//printf("[RGON] kinda string filename: %s %s \n", copyOfFileString.c_str(), g_FileManager_kinda->GetExpandedPath(copyOfFileString.c_str()));
@@ -44,7 +46,7 @@ void ASMPatchRedirectToLocalizedResources() {
 	signature.Scan();
 
 	void* addr = signature.GetAddress();
-	printf("[REPENTOGON] Patching ModManager::TryRedirectPath for testing at %p\n", addr);
+	printf("[REPENTOGON] Patching ModManager::TryRedirectPath for resources folder redirect at %p\n", addr);
 
 	patch.PreserveRegisters(savedRegisters)
 		.Push(ASMPatch::Registers::EBP, -0xa0) // RedirectedPath*
@@ -60,6 +62,81 @@ void ASMPatchRedirectToLocalizedResources() {
 	sASMPatcher.PatchAt(addr, &patch);
 }
 
+bool __stdcall TryToRedirectToLocalizedContent(std::string& resFileString, std::string& targetFile) {
+	auto copyOfFileString = resFileString;
+	auto* manager = g_Manager->GetModManager();
+	auto* langCode = g_Manager->GetLanguage();
+
+	if (g_Manager->_stringTable.language == 0 || targetFile[0] == '\0') {
+		return false;
+	}
+
+	//std::cout << targetFile << std::endl;
+	copyOfFileString = resFileString + "." + langCode + "/" + targetFile;
+
+	//printf("[RGON] kinda string filename: %s %s \n", copyOfFileString.c_str(), g_FileManager_kinda->GetExpandedPath(copyOfFileString.c_str()));
+
+	if (g_FileManager_kinda->GetExpandedPath(copyOfFileString.c_str()) != NULL) {
+
+		resFileString = copyOfFileString;
+
+		std::cout << "[REPENTOGON] Patched path: " << resFileString << std::endl;
+
+		return true;
+	}
+
+
+	return false;
+}
+
+//need to push to esp+4 carefully somehow, maybe will tweak later. For now using method hooking to redirect path.
+void ASMPatchRedirectToLocalizedContents() {
+	ASMPatch::SavedRegisters savedRegisters(ASMPatch::SavedRegisters::Registers::GP_REGISTERS, true);
+	ASMPatch patch;
+
+	SigScan signature("6a0668????????8d4d??c745??00000000");
+	signature.Scan();
+
+	void* addr = signature.GetAddress();
+	printf("[REPENTOGON] Patching ModEntry::GetContentPath for content folder redirect at %p\n", addr);
+
+	patch.PreserveRegisters(savedRegisters)
+		.Push(ASMPatch::Registers::ESI) // Target file
+		.Push(ASMPatch::Registers::EAX) //Mod content folder
+		.AddInternalCall(TryToRedirectToLocalizedContent)
+		.AddBytes("\x84\xC0") // test al, al
+		.RestoreRegisters(savedRegisters)
+		.AddBytes("\x74\x08")
+		.CopyRegister(ASMPatch::Registers::EDI, ASMPatch::Registers::EAX)
+		.AddConditionalRelativeJump(ASMPatcher::CondJumps::JNZ, (char*)addr + 0x16D) // jump for true
+		.AddBytes(ByteBuffer().AddAny((char*)addr, 0x7))  // Restore the commands we overwrote
+		.AddRelativeJump((char*)addr + 0x7);
+	sASMPatcher.PatchAt(addr, &patch);
+}
+
+HOOK_METHOD(ModEntry, GetContentPath, (std::string& resFileString, std::string& targetFile) -> void) {
+	super(resFileString, targetFile);
+	auto* manager = g_Manager->GetModManager();
+	auto* langCode = g_Manager->GetLanguage();
+
+	if (g_Manager->_stringTable.language == 0 || targetFile[0] == '\0') {
+		return;
+	}
+
+	auto copyOfContentDirectory = _contentDirectory.substr(0, _contentDirectory.length() - 1);
+
+	copyOfContentDirectory = copyOfContentDirectory + "." + langCode + "/" + targetFile;
+
+	if (g_FileManager_kinda->GetExpandedPath(copyOfContentDirectory.c_str()) != NULL) {
+
+		resFileString = copyOfContentDirectory;
+
+		std::cout << "[REPENTOGON] Patched path: " << resFileString << std::endl;
+	}
+
+}
+
 void ASMPatchRedirectToLocalizationFolders() {
 	ASMPatchRedirectToLocalizedResources();
+	//ASMPatchRedirectToLocalizedContents();
 }

--- a/repentogon/Patches/ASMPatches/ASMLocalization.h
+++ b/repentogon/Patches/ASMPatches/ASMLocalization.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void ASMPatchRedirectToLocalizationFolders();


### PR DESCRIPTION
The following changes add a couple of patches that redirect the paths to mod files to folders that have language codes postfixes if they exist.

To-do:
- [ ] Resources folders support
- [ ] Content folders support
- [ ] Update RGONFilemap redirection to support localization resources/content folders
- [ ] -DLC3 resources/content folders support