### PR TITLE
Separate stage portrait sprite for players.xml

### DIFF
--- a/libzhl/functions/ASM.zhl
+++ b/libzhl/functions/ASM.zhl
@@ -92,3 +92,6 @@ asm Player_AstralProjectionDeathSoundOverride "c74424??d9000000e8????????f30f104
 
 asm Camera_ClampOverride "74??8b45??f30f1128";
 asm Camera_SlowStopClampOverride "894f??8b40??8947??a1";
+
+// Custom stageportrait attribute
+asm StagePortrait_PortraitOverride "8bbd????????83c64c";


### PR DESCRIPTION
This PR adds (restores) new ``stageportrait`` attribute for players.xml config, which defines sprite for stage/nightmare transition cutscene

https://github.com/user-attachments/assets/7e5b9633-5dc6-40bb-bd17-1f89db3e797e

