### PR TITLE
Add RoomConfig(Set)::LoadStb

### DIFF
--- a/libzhl/functions/RoomConfig.zhl
+++ b/libzhl/functions/RoomConfig.zhl
@@ -24,6 +24,9 @@ RoomConfigRoomPtrVector RoomConfig::GetRooms(int stage, int type, int shape, int
 "558bec83c8ff":
 static cleanup int RoomConfig::get_door_from_position(int16_t posX<ecx>, int16_t posY<edx>, int shape);
 
+"558bec83ec448b45??53566bf25c":
+static cleanup void RoomConfig::read_room(RoomSet* set<ecx>, int idx<edx>, int stageId, KAGE_Filesys_IFile* file);
+
 "558bec518b55??8b45":
 __thiscall void RoomConfig::ResetRoomWeights(unsigned int Stage, int Mode);
 

--- a/libzhl/functions/RoomSpawn.zhl
+++ b/libzhl/functions/RoomSpawn.zhl
@@ -3,7 +3,7 @@ struct RoomSpawn depends (RoomEntry)
     uint16_t X : 0x0;
     uint16_t Y : 0x2;
     RoomEntry* Entries : 0x4;
-    uint16_t CountEntries : 0x8;
+    uint8_t CountEntries : 0x8;
     float SumWeights : 0xC;
 
     {{

--- a/repentogon/LuaInterfaces/Room/LuaRoomConfig.cpp
+++ b/repentogon/LuaInterfaces/Room/LuaRoomConfig.cpp
@@ -152,6 +152,25 @@ LUA_FUNCTION(Lua_RoomConfig_AddRooms)
 	return 1;
 }
 
+LUA_FUNCTION(Lua_RoomConfig_LoadStb)
+{
+	uint32_t stageId = (uint32_t)luaL_checkinteger(L, 1);
+	int mode = (int)luaL_checkinteger(L, 2);
+
+	if (0 > stageId || stageId >= NUM_STB) {
+		return luaL_argerror(L, 1, REPENTOGON::StringFormat("invalid stage %d", stageId).c_str());
+	}
+
+	if (-1 > mode || mode > 1) {
+		return luaL_argerror(L, 2, REPENTOGON::StringFormat("invalid mode %d", stageId).c_str());
+	}
+
+	const char* filename = luaL_checkstring(L, 3);
+
+	VirtualRoomSetManager::__AddStbRooms(L, stageId, mode, filename);
+	return 1;
+}
+
 static void RegisterRoomConfig(lua_State* L) {
 	//lua::RegisterFunction(L, lua::Metatables::GAME, "GetRoomConfig", Lua_GameGetRoomConfig);
 	lua_newtable(L);
@@ -159,6 +178,7 @@ static void RegisterRoomConfig(lua_State* L) {
 	lua::TableAssoc(L, "GetRandomRoom", Lua_RoomConfig_GetRandomRoom);
 	lua::TableAssoc(L, "GetStage", Lua_RoomConfig_GetStage);
 	lua::TableAssoc(L, "AddRooms", Lua_RoomConfig_AddRooms);
+	lua::TableAssoc(L, "LoadStb", Lua_RoomConfig_LoadStb);
 	lua_setglobal(L, "RoomConfig");
 }
 

--- a/repentogon/LuaInterfaces/Room/LuaRoomConfigSet.cpp
+++ b/repentogon/LuaInterfaces/Room/LuaRoomConfigSet.cpp
@@ -39,6 +39,13 @@ LUA_FUNCTION(Lua_RoomConfigSetAddRooms)
 	return 1;
 }
 
+LUA_FUNCTION(Lua_RoomConfigSetLoadStb) {
+	VirtualRoomSetManager::RoomSet* set = *lua::GetRawUserdata<VirtualRoomSetManager::RoomSet**>(L, 1, lua::metatables::RoomConfigSetMT);
+	const char* filename = luaL_checkstring(L, 2);
+	VirtualRoomSetManager::__AddStbRooms(L, set->GetStageId(), set->GetMode(), filename);
+	return 1;
+}
+
 static void RegisterRoomConfigSet(lua_State* L) {
 	luaL_newmetatable(L, lua::metatables::RoomConfigSetMT);
 	lua_pushstring(L, "__index");
@@ -66,6 +73,7 @@ static void RegisterRoomConfigSet(lua_State* L) {
 		{ "Get", Lua_RoomConfigSetGetRoom },
 		{ "__len", Lua_RoomConfigSetGetSize },
 		{ "AddRooms", Lua_RoomConfigSetAddRooms },
+		{ "LoadStb", Lua_RoomConfigSetLoadStb },
 		{ NULL, NULL }
 	};
 

--- a/repentogon/Patches/VirtualRoomSets.h
+++ b/repentogon/Patches/VirtualRoomSets.h
@@ -242,6 +242,8 @@ public:
 	static void __GetRooms(std::vector<RoomConfig_Room*>& result, uint32_t stageId, uint32_t roomType, uint32_t roomShape, uint32_t minVariant, uint32_t maxVariant, int minDifficulty, int maxDifficulty, uint32_t doors, int subType, int mode);
 	static bool __TryWriteRestoredVirtualRoom(RoomConfig_Room& roomConfig, GameStateRoomConfig& gameStateRoom);
 	static void __AddLuaRooms(lua_State* L, uint32_t stageId, int mode, int tableIndex);
+	// `filename` is expected to correspond to file(s) found @ `<mod root>/content/rooms/<filename>`
+	static void __AddStbRooms(lua_State* L, uint32_t stageId, int mode, std::string filename);
 	static RoomConfig_Room* __ReadRestoredVirtualRoom(GameStateRoomConfig& gameStateRoom);
 
 private:

--- a/repentogon/RoomConfigUtility.cpp
+++ b/repentogon/RoomConfigUtility.cpp
@@ -388,7 +388,7 @@ std::optional<RoomSpawn> RoomConfigUtility::BuildSpawnFromLua(lua_State* L, int 
 		return roomSpawn;
 	}
 
-	roomSpawn.CountEntries = (uint16_t)spawnEntries.size();
+	roomSpawn.CountEntries = (uint8_t)spawnEntries.size();
 	roomSpawn.Entries = new RoomEntry[roomSpawn.CountEntries];
 
 	for (size_t i = 0; i < roomSpawn.CountEntries; i++)
@@ -751,7 +751,7 @@ std::optional<RoomSpawn> RoomConfigUtility::DeserializeRoomSpawn(const rapidjson
 		auto spawnEntries = deserialize_spawn_entries_node(it->value, logContext);
 		if (!spawnEntries.empty())
 		{
-			roomSpawn.CountEntries = (uint16_t)spawnEntries.size();
+			roomSpawn.CountEntries = (uint8_t)spawnEntries.size();
 			roomSpawn.Entries = new RoomEntry[roomSpawn.CountEntries];
 			for (size_t i = 0; i < roomSpawn.CountEntries; i++)
 			{


### PR DESCRIPTION
Allows virtual rooms to be loaded from a content folder stb file. Otherwise behaves the same as existing virtual room support provided for the luaroom format.

The filepath provided to the function is relative, starting from `<mod>/content(-repentogon)/rooms/`. If multiple mods have matching files, they will all be loaded. This is consistent behavior for content files, and mods will be somewhat responsible for avoiding collisions.

The game's own logic for reading rooms from an stb file was able to be used for this purpose, though we need to make a copy of it so that we own the memory allocated for the Spawns and such.

Small note for a change introduced by this PR: I am pretty confident that `RoomSpawn::CountEntries` is `uint8_t`, not `uint16_t`. I had an issue with this due to using the game's own code to generate the spawn data. I've updated the zhl accordingly. For evidence, refer to the assembly for `RoomConfig::Spawn::Entries` (byte ptr). `uint16_t` is correct for `RoomConfigRoom::SpawnCount` though (word ptr).