### PR TITLE
improve linux launch command sed script

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -93,7 +93,7 @@ If you wish, you can make it so that launching Isaac through Steam runs the REPE
 * Return to the prior Steam menu and navigate to `General`
 * In the `Launch Options` field, copy and paste the following:
 ```
-echo "%command%" | sed -e 's/isaac-ng.exe/REPENTOGONLauncher\/REPENTOGONLauncher.exe/' | sh
+echo "%command%" | sed 's|isaac-ng.exe|REPENTOGONLauncher/REPENTOGONLauncher.exe|' | sh
 ```
     * Launching Isaac through Steam will now launch the REPENTOGON Launcher instead
 


### PR DESCRIPTION
this small change improves the sed command used in steam's launch options on linux in 2 ways:
* removes the unnecessary -e, as it is only needed if multiple scripts are to be run in a single sed command
* changes the delimiter in the sed script to | from / as doing so removes the requirement for the contained / to be escaped. this additionally makes it clearer to read since the script includes file paths that contain / as the separator.