### PR TITLE
Fix modded filemap entries not properly generating

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-v1.1.2e -
+v1.1.2h -
 Added:
 * Isaac:
 	- OpenConsole()
@@ -40,6 +40,7 @@ Fixes:
 	- Fixed being unable to add modded items to itempools.xml if they use a localization string name.
 	- Fixed specifying a tainted counterpart using bskinparent in players.xml not working properly for localized names.
 	- Content .anm2 file animations that use the character's name will now fall back to the English name (or raw string) if an animation matching the current localized name is not found.
+* Fixed modded filemap generation setting sometimes failing to load files
 /newline/
 /versionseparator/
 v1.1.2g -

--- a/repentogon/REPENTOGONFileMap.cpp
+++ b/repentogon/REPENTOGONFileMap.cpp
@@ -53,7 +53,7 @@ namespace REPENTOGONFileMap {
 		};
 	};
 	std::wstring wpathbuf(260, 0);
-	std::wstring_view relpath;
+	std::wstring relpath;
 	std::wstring tokenholder;
 	std::wstring outputholder;
 	std::wistringstream normalize_stringstream;
@@ -116,7 +116,7 @@ namespace REPENTOGONFileMap {
 		for (const auto& file : fs::recursive_directory_iterator(input, fs::directory_options::skip_permission_denied)) {
 			if (!file.is_directory()) {
 				//                const char* relpath = file.path().string().c_str() + moddir.string().size() + 1;   //account for "\\"
-				relpath = std::wstring_view{ file.path().wstring() }.substr(moddir.wstring().size() + 1);
+				relpath = std::wstring{ file.path().wstring() }.substr(moddir.wstring().size() + 1);
 				AddModEntry(relpath, modfoldertype, modid);
 			};
 		};


### PR DESCRIPTION
Our custom filemap gen has had an issue since its creation where, seemingly arbitrarily, modded files would fail to load. Reports seemed to suggest it happening more often on Linux, but I don't have any evidence for that.

After lots of logging i found that in cases where the entry generation failed, trying to log `relpath` would immediately terminate the logged string.

Expected:
```
[2026-08-29 19:25:54] [FindFiles] I'm trying to add Z:/var/home/nami/.local/share/Steam/steamapps/common/The Binding of Isaac Rebirth/mods/the binding of isaac sacrilege soundtrack_3727170471\resources\music\end times.ogg with relpath music\end times.ogg!
[2026-08-29 19:25:54] [AddModEntry] I'm adding music/end times.ogg under hash 1412984731!

```
Failure:
```
[2026-08-29 19:25:54] [FindFiles] I'm trying to add Z:/var/home/nami/.local/share/Steam/steamapps/common/The Binding of Isaac Rebirth/mods/the binding of isaac sacrilege soundtrack_3727170471\resources\music\fight ogg\be done intro.ogg with relpath [2026-08-29 19:25:54] [AddModEntry] I'm adding
```

I still don't understand the root issue, but changing `relpath` from `std::wstring_view` to a standard `std::wstring` has fixed it.